### PR TITLE
Fixed MixinClientPlayerEntity mixing loading error on server side

### DIFF
--- a/fabric/src/main/resources/caelus.mixins.json
+++ b/fabric/src/main/resources/caelus.mixins.json
@@ -5,9 +5,11 @@
   "compatibilityLevel": "JAVA_16",
   "mixins": [
     "MixinCaelusApi",
-    "MixinClientPlayerEntity",
     "MixinLivingEntity",
     "MixinPlayerEntity"
+  ],
+  "client": [
+    "MixinClientPlayerEntity"
   ],
   "server": [],
   "injectors": {


### PR DESCRIPTION
Changed trinkets.mixins.json so that MixinClientPlayerEntity is a client mixin, avoiding the following error message on server:
```
[main/WARN]: Error loading class: net/minecraft/class_746 (java.lang.ClassNotFoundException: net/minecraft/class_746)
[main/WARN]: @Mixin target net.minecraft.class_746 was not found caelus.mixins.json:MixinClientPlayerEntity
```